### PR TITLE
fix: 在rn上判断身份证始终都是false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ const checkBirthday = (IDCard = '') => {
   const diffYear =
     new Date().getFullYear() -
     new Date(
-      `${birthdayMatch[2]}/${birthdayMatch[3]}/${birthdayMatch[4]}`
+      `${birthdayMatch[2]}-${birthdayMatch[3]}-${birthdayMatch[4]}`
     ).getFullYear();
   // 年龄在0-130之间，目前中国没有超过130岁的
   return diffYear >= 0 && diffYear <= 130;


### PR DESCRIPTION
<img width="580" alt="image" src="https://user-images.githubusercontent.com/29084441/160070156-0afc2b8a-72a2-4f90-9ad3-5c3605be3901.png">
<img width="334" alt="image" src="https://user-images.githubusercontent.com/29084441/160070180-ed927eb3-f39e-4c3f-bd57-da8c10ee6f20.png">

在`rn`上`new Date('YYYY/MM/DD').getFullYear()`始终都是`NaN`