### PR TITLE
ci(release): add id-token write permission for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Grants `id-token: write` to the release workflow so npm can use OIDC provenance publishing instead of falling back to `NPM_TOKEN`.

Note: PR #50 referenced Dependabot alert numbers with `Closes #157` / `Closes #158`; those are Dependabot security alerts, not regular issues, which caused `@semantic-release/github` to fail in the `success` step. Future security fixes should use `Relates to` or the advisory URL instead of `Closes`.