### PR TITLE
ci(release): remove redundant PDF copy step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,6 @@ jobs:
       - name: Build VitePress
         run: pnpm run docs:build
 
-      - name: Copy PDF to output
-        run: cp docs/GB_11643-1999_公民身份号码.pdf pages/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
VitePress already copies files from `docs/public/` into the build output directory (configured as `../pages`). The manual `cp` step referenced the wrong source path and caused the release workflow to fail.

Removes the redundant copy step so the PDF is deployed via the standard VitePress public assets mechanism.