### PR TITLE
chore(deps): bump undici overrides to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,8 +139,8 @@
       "picomatch@>=4": "4.0.4",
       "brace-expansion@<2": "1.1.16",
       "brace-expansion@>=2": "2.1.2",
-      "undici@<7": "6.27.0",
-      "undici@>=7": "7.28.0",
+      "undici@<7": "6.28.0",
+      "undici@>=7": "7.29.0",
       "vite@5": "6.4.3"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ overrides:
   picomatch@>=4: 4.0.4
   brace-expansion@<2: 1.1.16
   brace-expansion@>=2: 2.1.2
-  undici@<7: 6.27.0
-  undici@>=7: 7.28.0
+  undici@<7: 6.28.0
+  undici@>=7: 7.29.0
   vite@5: 6.4.3
 
 importers:
@@ -3448,12 +3448,12 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -3805,7 +3805,7 @@ snapshots:
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.27.0
+      undici: 6.28.0
 
   '@actions/io@3.0.2': {}
 
@@ -4598,7 +4598,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.8(typescript@5.9.3)
       tinyglobby: 0.2.15
-      undici: 7.28.0
+      undici: 7.29.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - kerberos
@@ -7133,9 +7133,9 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.27.0: {}
+  undici@6.28.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 


### PR DESCRIPTION
## 变更内容

升级 `pnpm.overrides` 中锁定的 `undici` 版本，修复 5 个未关闭的 Dependabot 安全警告：

| Alert | Severity | CVE | 修复版本 |
|-------|----------|-----|----------|
| #165 | moderate | CVE-2026-15157 | `>= 6.28.0` |
| #164 | moderate | CVE-2026-14643 | `>= 7.29.0` |
| #163 | moderate | CVE-2026-16729 | `>= 6.28.0` |
| #162 | moderate | CVE-2026-16728 | `>= 6.28.0` |
| #161 | high | CVE-2026-13697 | `>= 7.29.0` |

## 具体修改

- `undici@<7`: `6.27.0` → `6.28.0`
- `undici@>=7`: `7.28.0` → `7.29.0`

## 验证

- [x] `pnpm run typecheck` 通过
- [x] `pnpm run typecheck:test` 通过
- [x] `pnpm run test` 通过（54/54）
- [x] `pnpm run lint` 通过

## 影响范围

`undici` 仅作为开发依赖的传递依赖使用（`@actions/http-client`、`@semantic-release/github`），不会进入库的分发包。