### PR TITLE
chore(deps): bump postcss override to 8.5.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "overrides": {
       "@conventional-changelog/git-client": "^2.5.1",
       "handlebars": "4.7.9",
-      "postcss": "8.5.18",
+      "postcss": "8.5.23",
       "js-yaml": "4.3.0",
       "lodash": "4.18.1",
       "lodash-es": "4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@conventional-changelog/git-client': ^2.5.1
   handlebars: 4.7.9
-  postcss: 8.5.18
+  postcss: 8.5.23
   js-yaml: 4.3.0
   lodash: 4.18.1
   lodash-es: 4.18.1
@@ -98,7 +98,7 @@ importers:
         version: 4.5.4(@types/node@25.2.0)(rollup@4.59.0)(typescript@5.9.3)(vite@8.1.5(@types/node@25.2.0)(esbuild@0.27.2)(terser@5.46.0)(yaml@2.8.2))
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.47.0)(@types/node@25.2.0)(lightningcss@1.33.0)(postcss@8.5.18)(search-insights@2.17.3)(terser@5.46.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 1.6.4(@algolia/client-search@5.47.0)(@types/node@25.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(search-insights@2.17.3)(terser@5.46.0)(typescript@5.9.3)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@16.7.0)(vite@8.1.5(@types/node@25.2.0)(esbuild@0.27.2)(terser@5.46.0)(yaml@2.8.2))
@@ -2982,8 +2982,8 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.28.3:
@@ -3617,7 +3617,7 @@ packages:
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
-      postcss: 8.5.18
+      postcss: 8.5.23
     peerDependenciesMeta:
       markdown-it-mathjax3:
         optional: true
@@ -4933,7 +4933,7 @@ snapshots:
       '@vue/shared': 3.5.27
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.18
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.27':
@@ -6618,7 +6618,7 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -7230,7 +7230,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -7244,7 +7244,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -7254,7 +7254,7 @@ snapshots:
       terser: 5.46.0
       yaml: 2.8.2
 
-  vitepress@1.6.4(@algolia/client-search@5.47.0)(@types/node@25.2.0)(lightningcss@1.33.0)(postcss@8.5.18)(search-insights@2.17.3)(terser@5.46.0)(typescript@5.9.3)(yaml@2.8.2):
+  vitepress@1.6.4(@algolia/client-search@5.47.0)(@types/node@25.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(search-insights@2.17.3)(terser@5.46.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.47.0)(search-insights@2.17.3)
@@ -7275,7 +7275,7 @@ snapshots:
       vite: 6.4.3(@types/node@25.2.0)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.2)
       vue: 3.5.27(typescript@5.9.3)
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'


### PR DESCRIPTION
## 变更内容

升级 `pnpm.overrides` 中锁定的 `postcss` 版本，修复 Dependabot 安全警告 #168。

| Alert | Severity | CVE | 影响版本 | 修复版本 |
|-------|----------|-----|----------|----------|
| #168 | moderate | CVE-2026-69153 | `<= 8.5.22` | `8.5.23` |

## 具体修改

- `postcss`: `8.5.18` → `8.5.23`

## 验证

- [x] `pnpm run typecheck` 通过
- [x] `pnpm run typecheck:test` 通过
- [x] `pnpm run test` 通过（54/54）
- [x] `pnpm run lint` 通过

## 影响范围

`postcss` 仅作为开发依赖的传递依赖使用，不会进入库的分发包。